### PR TITLE
use enum for types of entities

### DIFF
--- a/model-uml.violet
+++ b/model-uml.violet
@@ -5,7 +5,7 @@
    <object class="com.horstmann.violet.ClassNode" id="ClassNode0">
     <void property="attributes">
      <void property="text">
-      <string>- name: String
+      <string>- type: ModelType
 - hp: int
 - atk: int
 - cd: int</string>
@@ -14,9 +14,9 @@
     <void property="methods">
      <void property="text">
       <string>+ Model()
-+ Model(name: String, hp: int, atk: int, cd: int)
-+ getName() : String
-+ setName(name: String)
++ Model(type: ModelType, hp: int, atk: int, cd: int)
++ getName() : ModelType
++ setName(type: ModelType)
 + getHp() : int
 + setHp(hp: int)
 + getAtk() : int
@@ -62,7 +62,7 @@
     <void property="methods">
      <void property="text">
       <string>+ AbstractPlant()
-+ AbstractPlant(name: String, cost: int, hp: int, atk: int, cd: int)
++ AbstractPlant(type: ModelType, cost: int, hp: int, atk: int, cd: int)
 + getCost() : int
 + setCost(cost: int)</string>
      </void>
@@ -104,7 +104,7 @@
     <void property="methods">
      <void property="text">
       <string>+ AbstractZombie()
-+ AbstractZombie(name: String, hp: int, atk: int, speed: int, cd: int)
++ AbstractZombie(type: ModelType, hp: int, atk: int, speed: int, cd: int)
 + getSpeed() : int
 + setSpeed(speed: int)</string>
      </void>

--- a/sysc3110 project/src/model/AbstractPlant.java
+++ b/sysc3110 project/src/model/AbstractPlant.java
@@ -8,8 +8,8 @@ public abstract class AbstractPlant extends Model{
 		super();
 	}
 
-	public AbstractPlant(String name, int cost, int hp, int atk, int cd) {
-		super(name,hp,atk,cd);
+	public AbstractPlant(ModelType type, int cost, int hp, int atk, int cd) {
+		super(type,hp,atk,cd);
 		this.cost = cost;
 	}
 

--- a/sysc3110 project/src/model/AbstractZombie.java
+++ b/sysc3110 project/src/model/AbstractZombie.java
@@ -8,8 +8,8 @@ public abstract class AbstractZombie extends Model {
 		super();
 	}
 
-	public AbstractZombie(String name, int hp, int atk, int speed, int cd) {
-		super(name, hp, atk, cd);
+	public AbstractZombie(ModelType type, int hp, int atk, int speed, int cd) {
+		super(type, hp, atk, cd);
 		this.speed = speed;
 	}
 

--- a/sysc3110 project/src/model/Bullet.java
+++ b/sysc3110 project/src/model/Bullet.java
@@ -10,7 +10,7 @@ public class Bullet extends Model{
 	}
 	
 	public Bullet(int atk, int speed) {
-		super("bullet",0,atk,0);
+		super(ModelType.BULLET,0,atk,0);
 		this.speed = speed;
 	}
 	

--- a/sysc3110 project/src/model/FastZombie.java
+++ b/sysc3110 project/src/model/FastZombie.java
@@ -4,7 +4,7 @@ public class FastZombie extends AbstractZombie {
 
 	public FastZombie() {
 		//name,hp,atk,speed,cd
-		super("fast zombie",100,10,2,2);
+		super(ModelType.FAST_ZOMBIE,100,10,2,2);
 	}
 	
 	public void attack(Model plant) {

--- a/sysc3110 project/src/model/Model.java
+++ b/sysc3110 project/src/model/Model.java
@@ -2,7 +2,7 @@ package model;
 
 public abstract class Model {
 
-	private String name; // name of plants/zombies
+	private ModelType type; // name of plants/zombies
 	private int hp; // heath point for plants / zombies
 	private int atk; // attack damage
 	private int cd; // waiting time for plants / zombies' next attack
@@ -12,20 +12,20 @@ public abstract class Model {
 		// TODO Auto-generated constructor stub
 	}
 
-	public Model(String name, int hp, int atk, int cd) {
+	public Model(ModelType type, int hp, int atk, int cd) {
 		super();
-		this.name = name;
+		this.type = type;
 		this.hp = hp;
 		this.atk = atk;
 		this.cd = cd;
 	}
 
-	public String getName() {
-		return name;
+	public ModelType getType() {
+		return type;
 	}
 
-	public void setName(String name) {
-		this.name = name;
+	public void setType(ModelType type) {
+		this.type = type;
 	}
 
 	public int getHp() {

--- a/sysc3110 project/src/model/ModelType.java
+++ b/sysc3110 project/src/model/ModelType.java
@@ -1,0 +1,5 @@
+package model;
+
+public enum ModelType {
+	BULLET, FAST_ZOMBIE, PEA_SHOOTER, SUN_FLOWER;
+}

--- a/sysc3110 project/src/model/PeaShooter.java
+++ b/sysc3110 project/src/model/PeaShooter.java
@@ -3,7 +3,7 @@ public class PeaShooter extends AbstractPlant{
 
 	public PeaShooter() {
 		//name, cost, hp, atk, cd
-		super("pean shooter",100,100,25,2);
+		super(ModelType.PEA_SHOOTER,100,100,25,2);
 		// TODO Auto-generated constructor stub
 	}
 	

--- a/sysc3110 project/src/model/SunFlower.java
+++ b/sysc3110 project/src/model/SunFlower.java
@@ -5,7 +5,7 @@ public class SunFlower extends AbstractPlant{
 
 	public SunFlower() {
 		//name,cost,hp,damage,cd
-		super("sun flower", 50, 50, 0, 3);
+		super(ModelType.SUN_FLOWER, 50, 50, 0, 3);
 		this.sp = sp;
 		// TODO Auto-generated constructor stub
 	}


### PR DESCRIPTION
I think enums should be used for types for multiple reasons:

If we want to change a type for some reason, we only need to change this one definition of an enum.
If you need a string you can call toString() on the enum.
Enum comparison is faster than String comparison, as it does not require the call to `equals()`